### PR TITLE
Fixed overflow in `threshold` calculation

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -897,7 +897,7 @@ static void run_z_probe() {
     int direction = -1;
     // Consider the glass touched if the raw ADC value is reduced by 5% or more.
     int analog_fsr_untouched = rawBedSample();
-    int threshold = analog_fsr_untouched * 95 / 100;
+    int threshold = analog_fsr_untouched * 19 / 20;
     while (!touching_print_surface(threshold)) {
       destination[Z_AXIS] += step * direction;
       prepare_move_raw();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -897,7 +897,7 @@ static void run_z_probe() {
     int direction = -1;
     // Consider the glass touched if the raw ADC value is reduced by 5% or more.
     int analog_fsr_untouched = rawBedSample();
-    int threshold = analog_fsr_untouched * 19 / 20;
+    int threshold = analog_fsr_untouched * 95L / 100;
     while (!touching_print_surface(threshold)) {
       destination[Z_AXIS] += step * direction;
       prepare_move_raw();


### PR DESCRIPTION
For ADC values over 344.916, the `analog_fsr_untouched * 95` subexpression would overflow 2^15, so the `threshold` value would be negative and thus the printer would crash into the bed when trying to calibrate.
