### PR TITLE
Add E_STEPS calc and fix SdFatUtil compile error

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -504,7 +504,20 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define XYZ_PULLEY_TEETH 20
 #define XYZ_STEPS (XYZ_FULL_STEPS_PER_ROTATION * XYZ_MICROSTEPS / double(XYZ_BELT_PITCH) / double(XYZ_PULLEY_TEETH))
 
-#define DEFAULT_AXIS_STEPS_PER_UNIT   {XYZ_STEPS, XYZ_STEPS, XYZ_STEPS, 170}
+// This E_STEPS calculation will result in an extrusion multiplier of 1 in slicer.
+// Use E_HOB_DIAM = 11.98343 to get original Kossel result of 170 E_STEPS.
+// Set both E_BIG_GEAR_TEETH and E_SMALL_GEAR_TEETH to 1 for direct drive stepper.
+// For geared stepper set gearing ratio as E_BIG_GEAR_TEETH:E_SMALL_GEAR_TEETH, i.e. for Classic Wade of 39:11, set E_BIG_GEAR_TEETH = 39, E_SMALL_GEAR_TEETH = 11.
+// See http://reprap.org/wiki/Drive-gear for hobbed gear diameters
+// See http://reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide for source of formula
+#define E_FULL_STEPS_PER_ROTATION 200
+#define E_MICROSTEPS 32
+#define E_HOB_DIAM 11.4
+#define E_BIG_GEAR_TEETH 1
+#define E_SMALL_GEAR_TEETH 1
+#define E_STEPS ((E_FULL_STEPS_PER_ROTATION * E_MICROSTEPS) * (E_BIG_GEAR_TEETH / double(E_SMALL_GEAR_TEETH)) / (double(E_HOB_DIAM) * double(3.14159265)))
+
+#define DEFAULT_AXIS_STEPS_PER_UNIT   {XYZ_STEPS, XYZ_STEPS, XYZ_STEPS, E_STEPS}
 #define DEFAULT_MAX_FEEDRATE          {200, 200, 200, 200}    // (mm/sec)
 #define DEFAULT_MAX_ACCELERATION      {9000,9000,9000,9000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
 

--- a/Marlin/SdFatUtil.cpp
+++ b/Marlin/SdFatUtil.cpp
@@ -22,24 +22,25 @@
 #ifdef SDSUPPORT
 #include "SdFatUtil.h"
 
+#ifdef __arm__
+// should use uinstd.h to define sbrk but Due causes a conflict
+extern "C" char* sbrk(int incr);
+#else  // __ARM__
+extern char *__brkval;
+extern char __bss_end;
+#endif  // __arm__
+
 //------------------------------------------------------------------------------
 /** Amount of free RAM
  * \return The number of free bytes.
  */
 int SdFatUtil::FreeRam() {
-  extern int  __bss_end;
-  extern int* __brkval;
-  int free_memory;
-  if (reinterpret_cast<int>(__brkval) == 0) {
-    // if no heap use from end of bss section
-    free_memory = reinterpret_cast<int>(&free_memory)
-                  - reinterpret_cast<int>(&__bss_end);
-  } else {
-    // use from top of stack to heap
-    free_memory = reinterpret_cast<int>(&free_memory)
-                  - reinterpret_cast<int>(__brkval);
-  }
-  return free_memory;
+  char top;
+#ifdef __arm__
+  return &top - reinterpret_cast<char*>(sbrk(0));
+#else  // __arm__
+  return __brkval ? &top - __brkval : &top - &__bss_end;
+#endif  // __arm__
 }
 //------------------------------------------------------------------------------
 /** %Print a string in flash memory.


### PR DESCRIPTION
Add E_STEPS calculation based on
http://reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide and
http://reprap.org/wiki/Drive-gear.

Fix compile error in SdFatUtil.cpp and latest Arduino IDE.
